### PR TITLE
✨ feat [#12] : 쿠폰 수량 감소 기능에 비관적 락 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
 
 dependencies {
     // common-module
-    implementation 'com.sparta.limited:common-module:1.2.5'
+    implementation 'com.sparta.limited:common-module:1.3.0'
 
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/sparta/limited/coupon_service/coupon/application/service/CouponService.java
+++ b/src/main/java/com/sparta/limited/coupon_service/coupon/application/service/CouponService.java
@@ -30,7 +30,7 @@ public class CouponService {
     public void decreaseQuantity(
         UUID couponId
     ) {
-        Coupon coupon = couponRepository.findById(couponId);
+        Coupon coupon = couponRepository.findByIdWithLock(couponId);
         coupon.decreaseQuantity();
     }
 

--- a/src/main/java/com/sparta/limited/coupon_service/coupon/domain/repository/CouponRepository.java
+++ b/src/main/java/com/sparta/limited/coupon_service/coupon/domain/repository/CouponRepository.java
@@ -8,4 +8,7 @@ public interface CouponRepository {
     void save(Coupon coupon);
 
     Coupon findById(UUID couponId);
+
+    Coupon findByIdWithLock(UUID couponId);
+
 }

--- a/src/main/java/com/sparta/limited/coupon_service/coupon/infrastructure/persistence/JpaCouponRepository.java
+++ b/src/main/java/com/sparta/limited/coupon_service/coupon/infrastructure/persistence/JpaCouponRepository.java
@@ -1,9 +1,17 @@
 package com.sparta.limited.coupon_service.coupon.infrastructure.persistence;
 
 import com.sparta.limited.coupon_service.coupon.domain.model.Coupon;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaCouponRepository extends JpaRepository<Coupon, UUID> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select c from Coupon c where c.id = :id")
+    Optional<Coupon> findByIdWithLock(UUID id);
 
 }

--- a/src/main/java/com/sparta/limited/coupon_service/coupon/infrastructure/repository/CouponRepositoryImpl.java
+++ b/src/main/java/com/sparta/limited/coupon_service/coupon/infrastructure/repository/CouponRepositoryImpl.java
@@ -24,4 +24,11 @@ public class CouponRepositoryImpl implements CouponRepository {
         return jpaCouponRepository.findById(couponId)
             .orElseThrow(() -> new CouponNotFoundException(couponId));
     }
+
+    @Override
+    public Coupon findByIdWithLock(UUID couponId) {
+        return jpaCouponRepository.findByIdWithLock(couponId)
+            .orElseThrow(() -> new CouponNotFoundException(couponId));
+    }
+
 }

--- a/src/test/java/com/sparta/limited/coupon_service/coupon/UserCouponTest.java
+++ b/src/test/java/com/sparta/limited/coupon_service/coupon/UserCouponTest.java
@@ -1,0 +1,80 @@
+package com.sparta.limited.coupon_service.coupon;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.sparta.limited.coupon_service.coupon.domain.model.Coupon;
+import com.sparta.limited.coupon_service.coupon.domain.repository.CouponRepository;
+import com.sparta.limited.coupon_service.user_coupon.application.service.UserCouponService;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class UserCouponTest {
+
+    private final static Logger log = LoggerFactory.getLogger(UserCouponTest.class);
+    private final Long couponQuantity = 100L;
+    @Autowired
+    private UserCouponService userCouponService;
+    @Autowired
+    private CouponRepository couponRepository;
+    private UUID couponId;
+
+    @BeforeEach
+    void setUpCoupon() {
+        Coupon coupon = Coupon.of(
+            "테스트용 쿠폰",
+            1,
+            couponQuantity
+        );
+        couponRepository.save(coupon);
+        couponId = coupon.getId();
+    }
+
+    @Test
+    @DisplayName("사용자 쿠폰 발급 동시성 테스트")
+    void createUserCouponTest() throws InterruptedException {
+        int numThreads = 1000;
+        ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        long testStartTime = System.currentTimeMillis();
+
+        for (int i = 0; i < numThreads; i++) {
+            final Long userId = i + 1L;
+            executorService.submit(() -> {
+                try {
+                    userCouponService.creatUserCoupon(couponId, userId);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        long testFinishTime = System.currentTimeMillis();
+        log.info("테스트 소요 시간 : " + (testFinishTime - testStartTime));
+        log.info("발급한 총 쿠폰 개수 : " + successCount.get());
+        log.info("발급 실패한 총 쿠폰 개수 : " + failCount.get());
+
+        assertEquals(couponQuantity, successCount.get());
+        assertEquals(numThreads - couponQuantity, failCount.get());
+    }
+
+}


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 쿠폰 재고 감소시 비관적 락 적용 후 테스트

* **세부 내용**
  * 쿠폰 재고 감소시 비관적 락 적용하여 쿠폰의 수량 초과 발급하지 못하도록 제어하였습니다.
  * 테스트 시나리오
    * 100개의 수량을 가지고 있는 쿠폰을 생성
    * 처음엔 100개의 쓰레드 풀을 지정하여 테스트 이후 1000, 2000, 3000 증가 테스트.
    * 비관적 락 적용 전 후 비교 테스트
  * 테스트 결과
    * 비관적 락이 적용된 테스트에서는 쓰레드 수 최대 5000까지 테스트 하였을때 100개 초과 발급은 일어나지 않았습니다.
    * 비관적 락이 적용되지 않은 테스트에서는 100개 발급은 정상처리 되었고, 1000개에서 893개 초과 발급, 2000개에서 913개 발급 후 더이상의 테스트는 의미가 없을 것 같아 중단했습니다.
  * 테스트 소요 시간
    * 2000개의 쓰레드 테스트 기준 
    * 비관적 락 : 1.107초 
    * 락 X : 1.780초
    * 락이 적용되지 않았을때 소요 시간이 더 긴 이유는 쿠폰 초과 발급량만큼 데이터베이스에 쓰기 작업이 늘어나서 그렇습니다.

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
* 동시성 테스트 코드 작성 참고 자료
  * https://velog.io/@mohai2618/%EB%8F%99%EC%8B%9C%EC%84%B1-%ED%99%98%EA%B2%BD-%ED%85%8C%EC%8A%A4%ED%8A%B8%ED%95%98%EA%B8%B0 
* 쓰레드 풀 참고 자료
  * https://steady-coding.tistory.com/548
