### PR TITLE
🩹 fix [#22] : 그래들 빌드시 테스트 실패 버그 수정

### DIFF
--- a/src/test/java/com/sparta/limited/coupon_service/coupon/CouponControllerTest.java
+++ b/src/test/java/com/sparta/limited/coupon_service/coupon/CouponControllerTest.java
@@ -59,7 +59,7 @@ public class CouponControllerTest {
     @BeforeEach
     void setUp() {
         Coupon coupon = Coupon.of(
-            "테스트용 쿠폰",
+            "컨트롤러 테스트용 쿠폰",
             10,
             10L
         );
@@ -80,7 +80,7 @@ public class CouponControllerTest {
     void createCoupon() throws Exception {
 
         CouponCreateRequest couponCreateRequest = CouponCreateRequest.of(
-            "테스트 쿠폰 생성",
+            "쿠폰 생성 테스트용 쿠폰",
             10,
             10L
         );

--- a/src/test/java/com/sparta/limited/coupon_service/user_coupon/UserCouponTest.java
+++ b/src/test/java/com/sparta/limited/coupon_service/user_coupon/UserCouponTest.java
@@ -17,7 +17,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 public class UserCouponTest {
 
@@ -32,7 +34,7 @@ public class UserCouponTest {
     @BeforeEach
     void setUpCoupon() {
         Coupon coupon = Coupon.of(
-            "테스트용 쿠폰",
+            "동시성 테스트용 쿠폰",
             1,
             couponQuantity
         );


### PR DESCRIPTION
## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [x] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 그래들 빌드시 테스트 실패 버그 수정

* **세부 내용**
  * 그래들 빌드시 성공했던 테스트 들이 실패로 표기
  * 빌드를 중단하고 각 테스트 코드 실행했을때 성공
  * create-drop 설정으로 그래들 빌드시에 자동으로 드랍하며 테스트가 넘어갈 것이라 생각
  * 하지만 그래들 빌드는 하나의 앱 실행으로 판정되어 빌드가 끝나기 전까지는 데이터베이스 drop이 발생하지 않음
  * 중복되는 쿠폰명을 수정하여 해결

## 💡 추가 설명

* 노션에 트러블 슈팅 작성했습니다!
